### PR TITLE
The settings Group is unnecessary

### DIFF
--- a/etc/openhab2/items/default.items
+++ b/etc/openhab2/items/default.items
@@ -2,7 +2,6 @@ Group charts
 Group chart_temp
 Group chart_humi
 Group chart_press
-Group settings
 
 /**
 //US

--- a/etc/openhab2/sitemaps/default.sitemap
+++ b/etc/openhab2/sitemaps/default.sitemap
@@ -37,7 +37,7 @@ sitemap default label="Main Menu"
   Frame label="Configuration" {
     Text item=SettingsPage label="Settings" {
       Frame {
-        Group item=settings label="Maintenance" icon="switch" {
+        Text label="Maintenance" icon="switch" {
           Frame {
             Switch item=BackupButton mappings=["ON"="Backup"]
             Switch item=RestoreButton mappings=["ON"="Restore"]
@@ -45,7 +45,7 @@ sitemap default label="Main Menu"
             Switch item=ShutdownButton mappings=["ON"="Shutdown"]
           }
         }
-        Group item=settings label="2nd Stage Heating" icon="heating" {
+        Text label="2nd Stage Heating" icon="heating" {
           Frame {
             Setpoint item=Heating2Delta minValue=0 maxValue=20 step=1 icon="temperature"
             Setpoint item=Heating2Time minValue=0 maxValue=120 step=1 icon="clock"


### PR DESCRIPTION
I started setting up restoreOnStartup with MapDB to preserve settings between openHAB restarts and I noticed this `Group settings` whose only use and sole purpose appears to be to let you use a Group element on the sitemap to get a subframe. 

You can get the exact same behavior on the sitemap using a Text element without any `item=`. It's the `{ }` that tells the sitemap renderer that you want to have a subframe. 

This PR removes the Group and uses the Text element in it's place. 

I've noticed similar odd approaches in some of the code I've reviewed so far learning how it all works together. As I find similar little easy changes I can continue to submit these little PRs or if you prefer I can create an Issue to track them. What ever makes the most sense for your workflow.

Signed-off-by: Rich Koshak <rlkoshak@gmail.com>