### PR TITLE
Fix for hotwater not restarting on reboot

### DIFF
--- a/home/pi/scripts/default.rules
+++ b/home/pi/scripts/default.rules
@@ -367,6 +367,15 @@ then
     }
   ]
 
+  // All the modes are set but they won't change to trigger the Mode rule below
+  // so call the lambdas to cause the devices to turn on/off as appropriate.
+  heating.apply(initLogName, TIMERS, heating_ctrl)
+  if(SystemType.state == "EU") {
+    humidity.apply(initLogName, TIMERS, humidity_ctrl)
+    hotwater.apply(initLogName, TIMERS, hotwater_ctrl)
+  }
+  else cooling.apply(initLogName, TIMERS, cooling_ctrl)
+
   logInfo(initLogName, "Done initializing settings")
 end
 
@@ -868,4 +877,3 @@ then
     logWARN("wanip", "Unable to get WAN IP")
   }
 end
-

--- a/home/pi/scripts/default.rules
+++ b/home/pi/scripts/default.rules
@@ -354,19 +354,6 @@ then
     m.sendCommand(resetVal) // Changing from Boost will reset the RemBoostTime Item and cancel the timers
   ]
 
-  // Send out the change to the current readings to kick off the selected mode.
-  // The sensor should have updated at least once while this Rule was running.
-  Sensors.members.forEach[ s |
-    if(s.state instanceof UnDefType) logError(logName, s.name + " doesn't have a value!")
-    else {
-      val type = s.name.replace("My", "")
-      logInfo(initLogName, "Sending " + s.state + " to " + s.name + "Proxy")
-      sendCommand(s.name+"Proxy", s.state.toString)
-      logInfo(initLogName, "Sending 0 to Previous"+type+"Reading")
-      sendCommand("Previous"+type+"Reading", "0")
-    }
-  ]
-
   // All the modes are set but they won't change to trigger the Mode rule below
   // so call the lambdas to cause the devices to turn on/off as appropriate.
   heating.apply(initLogName, TIMERS, heating_ctrl)


### PR DESCRIPTION
Fixes #31.

Because the Mode Items do not change when recommanding them the Mode Rule never executes to kick off the changes to the devices. Previously I kicked things off by changing the sensor readings but HotWater is not based on a sensor reading. So I change to just call the lambdas directly for all the devices. Therefore, at the end of initializing if the Mode is ON, the device will turn ON.

Signed-off-by: Richard Koshak <rlkoshak@gmail.com>