### PR TITLE
Fan auto

### DIFF
--- a/etc/openhab2/sitemaps/default.sitemap
+++ b/etc/openhab2/sitemaps/default.sitemap
@@ -21,7 +21,7 @@ sitemap default label="Main Menu"
 
   Frame label="Fan" visibility=[SystemType=="US"] {
     Text item=FanPin label="Fan [%s]" icon="switch" visibility=[FanCtrl==OFF]
-    Switch item=FanMode mappings=[ "ON"="ON", "OFF"="OFF", "AUTO"="AUTO"] visibility=[FanCtrl!=OFF]
+    Switch item=FanMode mappings=[ "ON"="ON", "OFF"="OFF"] visibility=[FanCtrl!=OFF]
   }
 
   Frame label="Heating" visibility=[SystemType=="EU"] {


### PR DESCRIPTION
Fixes #9 by removing the AUTO option from the sitemap. The controls will completely hide when Heating or Cooling is active, disabling the ability to change the fan until heating or cooling turns off.

Signed-off-by: Richard Koshak rlkoshak@gmail.com

