### PR TITLE
Restore FanMode after AUTO, don't start boost when changing BoostTime item

### DIFF
--- a/home/pi/scripts/default.rules
+++ b/home/pi/scripts/default.rules
@@ -81,7 +81,6 @@ val heating_ctrl = [ String logName, Map<String, Timer> TIMERS, OnOffType cmd |
       HeatingPin.sendCommand(OFF)
       if(SystemType.state == "US") {
         createTimer(now.plusSeconds(1), [ |
-          logInfo(logName, "FanPrevMode = " + FanPrevMode.state)
           FanMode.sendCommand(if(FanPrevMode.state.toString != "ON") "OFF" else "ON")
           FanCtrl.sendCommand(ON)
         ])

--- a/home/pi/scripts/default.rules
+++ b/home/pi/scripts/default.rules
@@ -81,7 +81,8 @@ val heating_ctrl = [ String logName, Map<String, Timer> TIMERS, OnOffType cmd |
       HeatingPin.sendCommand(OFF)
       if(SystemType.state == "US") {
         createTimer(now.plusSeconds(1), [ |
-          FanPin.sendCommand(OFF)
+          logInfo(logName, "FanPrevMode = " + FanPrevMode.state)
+          FanMode.sendCommand(if(FanPrevMode.state.toString != "ON") "OFF" else "ON")
           FanCtrl.sendCommand(ON)
         ])
       }
@@ -173,7 +174,7 @@ val cooling_ctrl = [ String logName, Map<String, Timer> TIMERS, OnOffType cmd |
     else {
       CoolingPin.sendCommand(OFF)
       createTimer(now.plusSeconds(1), [ |
-        FanPin.sendCommand(OFF)
+        FanMode.sendCommand(if(FanPrevMode.state.toString != "ON") "OFF" else "ON")
         FanCtrl.postUpdate(ON) // show controls on sitemap
       ])
     }
@@ -287,6 +288,10 @@ when
     System started
 then
   val initLogName = "initialization"
+
+  // Temporary exec.whitelist work around
+  // executeCommandLine("/usr/bin/touch@@/etc/openhab2/misc/exec.whitelist")
+
 
   logInfo(initLogName, "Initializing settings")
 
@@ -570,7 +575,9 @@ then
   val decide = DECIDE_LAMBDAS.get(mode)
   val ctrl = CTRL_LAMBDAS.get(mode)
 
-  if(triggeringItem.state.toString != "Boost") postUpdate(mode+"PrevMode", triggeringItem.state.toString)
+  if(triggeringItem.state.toString != "Boost" &&
+     triggeringItem.state.toString != "AUTO")
+    postUpdate(mode+"PrevMode", triggeringItem.state.toString)
 
   switch(triggeringItem.state){
     case "ON", case "AUTO": decide.apply(logName, TIMERS, ctrl)
@@ -712,7 +719,7 @@ when
 then
   val remTime = ScriptServiceUtil.getItemRegistry.getItem(triggeringItem.name.replace("BoostTime", "RemBoostTime"))
 
-  if((remTime.state instanceof DecimalType) && remTime.state as Number != 0)
+  if((remTime.state instanceof DecimalType) && remTime.state as Number > 0)
     remTime.sendCommand(triggeringItem.state.toString)
 end
 


### PR DESCRIPTION
This PR includes two bug fixes.

1. When the Fan goes to AUTO mode because the heating or cooling turn on, return FanMode to it's previous state when the heating/cooling is done. 

2. Only update the corresponding RemBoostTime Item when the BoostTime Item changes if the device is already in Boost mode. Updating it all the time causes boost mode to turn on.

There is also a new line, commented out, in the initialization rule that touches the exec.whitelist file so the exec scripts don't get stuck. This should be removed once the bug in the Exce binding is fixed.

Signed-off-by: Richard Koshak <rlkoshak@gmail.com>