### PR TITLE
Corrected URL for the PaperUI

### DIFF
--- a/docs/configuration.tex
+++ b/docs/configuration.tex
@@ -27,7 +27,7 @@ certainly point you in the right direction. Installation instructions on the
 above link.  Alternatively you can use my.openhab.org which is a service hosted
 externally and is not controlled by us or you but by OpenHAB itself. Go to:
 
-\texttt{http://[YOUR-HESTIAPI-IP]:8080/paperui}
+\texttt{http://[YOUR-HESTIAPI-IP]:8080/paperui/index.html}
 
 and select Add-ons > MISC and install ``openHAB Cloud Connector'' if not
 installed. Once installed SSH into your HestiaPi (username: pi and password:

--- a/docs/easy_remote_access.tex
+++ b/docs/easy_remote_access.tex
@@ -9,7 +9,7 @@ you or us but by OpenHAB itself.}
 prefer video to text)
 
 To activate it (shipped disabled by default for obvious reasons) go to
-http://[YOUR-HESTIAPI-IP]:8080/paperui and select Add-ons > MISC and make
+http://[YOUR-HESTIAPI-IP]:8080/paperui/index.html and select Add-ons > MISC and make
 sure ``openHAB Cloud Connector'' is installed.
 
 Once installed SSH into your HestiaPi (username: pi and password: hestia) and

--- a/docs/remote_temp_sensors.tex
+++ b/docs/remote_temp_sensors.tex
@@ -18,7 +18,7 @@ on \ref{Ruuvi Temperature Sensors}.
 After you've done this, the data is being sent to the HestiaPi, but we need to
 reconfigure the thermostat to use this new data. This will be done via the web
 interface, and specifically the PaperUI. You can get to this by navigating to
-http://[YOUR-HESTIAPI-IP]:8080/paperui (where you insert the IP address of your
+http://[YOUR-HESTIAPI-IP]:8080/paperui/index.html (where you insert the IP address of your
 HestiaPi in labeled location).
 
 We will walk through an example which sets up a temperature sensor in the living


### PR DESCRIPTION
This change is based on feedback from a community member, and I was able to reproduce their findings.

The PaperUI doesn't load properly if you navigate to http://IPADDR:8080/paperui it has to be http://IPADDR:8080/paperui/index.html

(and the other commit is because I forget to commit the generated .pdf file when I did the updates to the troubleshooting section)