### PR TITLE
Fix SSID and Disk space scripts

### DIFF
--- a/home/pi/scripts/getssid.sh
+++ b/home/pi/scripts/getssid.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-/sbin/iwconfig wlan0 | grep 'SSID:"' | awk '{print $4}' | cut -d\" -f2;
+/sbin/iwconfig wlan0 | grep -oP 'ESSID:"\K[^"]*'

--- a/home/pi/scripts/getuseddiskspace.sh
+++ b/home/pi/scripts/getuseddiskspace.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-used=$(df | grep root  | awk '{print $5}' | sed 's/%.*//g')
+used=$(df -P / | awk 'NR==2 {print $5}' | tr -d '%')
 echo $used "%"


### PR DESCRIPTION
Closes #97 and #98. See those issues for more details. 

This MR fixes a bug where disk space appears as blank, and a bug where only the first word of the SSID will show up. 